### PR TITLE
Add React frontend and Node backend with Mongo projects API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,52 @@
-Here’s a README template for **FullStack Pilot** in English:
-
----
-
 # FullStack Pilot
 
-**FullStack Pilot** is a self-organized full-stack service designed to simplify and automate the development and management of modern applications. It provides seamless integration between *micro-UI*, *micro-services*, and DevOps tools, enabling rapid and efficient setup of your full-stack projects.
+A minimal full-stack starter that pairs a React frontend with a Node.js + MongoDB backend. The UI lets you add and remove projects from a list, and the API persists them in a Mongo database.
 
-## 🚀 Features
+## Prerequisites
+- Node.js 18+
+- MongoDB instance (local or remote)
 
-- **Micro-UI Architecture**: Easily integrate modular React components for dynamic and responsive user interfaces.
-- **Node.js Micro-Services**: Simplified development and management of micro-services with ready-to-use tools.
-- **CI/CD Automation**: Integration with CI/CD pipelines for continuous delivery with minimal effort.
-- **Pre-configured Templates**: Templates and tools for quick setup of infrastructure as code (IaC) and DevOps configurations.
-- **Comprehensive Documentation**: Detailed guides for installation, configuration, and usage of the various components.
+## Project structure
+- `client/` – React UI built with Vite.
+- `server/` – Express + Mongoose API service.
 
-## 📦 Installation
+## Getting started
 
-1. **Clone the repository**:
-   ```bash
-   git clone https://github.com/koydas/fullstack-pilot.git
-   cd fullstack-pilot
-   ```
+### 1) Install dependencies
+Run the following commands from the repository root:
+```bash
+cd server && npm install
+cd ../client && npm install
+```
 
-2. **Install dependencies**:
-   ```bash
-   npm install
-   npm run new <my-app> # by default: nextJS
-   
-   
-   ```
+> If your environment restricts access to the npm registry, configure the registry your network allows before running the installs.
 
-3. **Configuration**: Follow the instructions in the `config.<my-app>.js` file to set up your environment.
+### 2) Configure environment
+Create a `.env` file in `server/` (or export variables in your shell):
+```
+MONGODB_URI=mongodb://localhost:27017/fullstack-pilot
+PORT=4000
+```
 
-4. **Start**:
-   ```bash
-   npm start
-   ```
+### 3) Start the backend
+```bash
+cd server
+npm run dev
+```
+The API will be available at `http://localhost:4000/api`.
 
-## 🛠️ Usage
+### 4) Start the frontend
+```bash
+cd client
+npm run dev
+```
+Open the printed Vite dev server URL (default `http://localhost:5173`). The dev server proxies `/api` requests to the backend.
 
-1. **Develop UI Components**: Add your React components to the `src/components` directory.
-2. **Create Micro-Services**: Develop and manage your micro-services in the `services` directory.
-3. **Deploy with CI/CD**: Configure your CI/CD pipelines using the configuration files provided in the `ci-cd` directory.
+## API overview
+- `GET /api/projects` – list projects
+- `POST /api/projects` – create a project. Body: `{ "name": "My project" }`
+- `DELETE /api/projects/:id` – delete a project by id
 
-## 📚 Documentation
-
-Refer to the comprehensive documentation in the `docs` directory for detailed guides and usage examples.
-
-## 🔧 Contributing
-
-1. **Fork the repository** and create a branch:
-   ```bash
-   git checkout -b my-feature-branch
-   ```
-
-2. **Add your changes** and **commit**:
-   ```bash
-   git add .
-   git commit -m "Add new feature"
-   ```
-
-3. **Push** and **create a Pull Request** on GitHub.
-
-## 📄 License
-
-This project is licensed under the [MIT](LICENSE) License.
-
-## 📧 Contact
-
-For any questions or suggestions, please contact: [your.email@example.com](mailto:your.email@example.com).
-
----
-
-> **Observation**: This template includes key sections for a README. Feel free to adjust or expand it based on the specific features of **FullStack Pilot** and your user needs.
+## Deployment notes
+- Set `MONGODB_URI` to your managed MongoDB connection string.
+- Use `npm run build` inside `client/` to create a production build. Serve the static assets with your preferred host and point them at the running backend.

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Project Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "fullstack-pilot-client",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.8",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.46",
+    "@types/react-dom": "^18.2.18",
+    "eslint": "^8.57.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: '/api',
+});
+
+function formatDate(value) {
+  return new Date(value).toLocaleString();
+}
+
+export default function App() {
+  const [projects, setProjects] = useState([]);
+  const [name, setName] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  async function loadProjects() {
+    try {
+      setLoading(true);
+      const { data } = await api.get('/projects');
+      setProjects(data);
+    } catch (err) {
+      setError(err?.response?.data?.error || 'Could not load projects');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function addProject(event) {
+    event.preventDefault();
+    if (!name.trim()) return;
+
+    try {
+      setLoading(true);
+      const { data } = await api.post('/projects', { name: name.trim() });
+      setProjects((prev) => [data, ...prev]);
+      setName('');
+      setError('');
+    } catch (err) {
+      setError(err?.response?.data?.error || 'Could not create project');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function removeProject(id) {
+    try {
+      await api.delete(`/projects/${id}`);
+      setProjects((prev) => prev.filter((project) => project._id !== id));
+    } catch (err) {
+      setError(err?.response?.data?.error || 'Could not remove project');
+    }
+  }
+
+  useEffect(() => {
+    loadProjects();
+  }, []);
+
+  return (
+    <div className="app-shell">
+      <header>
+        <div className="logo" aria-hidden="true" />
+        <div>
+          <p style={{ margin: 0, color: '#475569' }}>FullStack Pilot</p>
+          <h1>Project Manager</h1>
+        </div>
+      </header>
+
+      <div className="card">
+        <form className="form-row" onSubmit={addProject}>
+          <input
+            type="text"
+            name="projectName"
+            placeholder="Enter a project name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            disabled={loading}
+            aria-label="Project name"
+          />
+          <button type="submit" disabled={loading || !name.trim()}>
+            Add project
+          </button>
+        </form>
+
+        {error && <p className="status-text">{error}</p>}
+
+        <div className="projects-list" aria-live="polite">
+          {projects.length === 0 && !loading && <p>No projects yet.</p>}
+
+          {projects.map((project) => (
+            <article key={project._id} className="project-item">
+              <div className="project-meta">
+                <span className="project-name">{project.name}</span>
+                <span className="project-date">Created {formatDate(project.createdAt)}</span>
+              </div>
+              <button
+                type="button"
+                className="secondary-button"
+                onClick={() => removeProject(project._id)}
+              >
+                Remove
+              </button>
+            </article>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1,0 +1,111 @@
+:root {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #0f172a;
+  background-color: #f8fafc;
+  line-height: 1.5;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.app-shell {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.logo {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #22c55e, #14b8a6);
+}
+
+h1 {
+  font-size: 1.8rem;
+  margin: 0;
+}
+
+.card {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  box-shadow: 0 10px 50px rgba(15, 23, 42, 0.05);
+  padding: 1.25rem;
+}
+
+.form-row {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+input[type='text'] {
+  flex: 1;
+  padding: 0.75rem 0.9rem;
+  border-radius: 10px;
+  border: 1px solid #cbd5e1;
+  font-size: 1rem;
+}
+
+button {
+  background: #22c55e;
+  color: white;
+  border: none;
+  padding: 0.75rem 1.1rem;
+  border-radius: 10px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.projects-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.project-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.9rem 1rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background: #f8fafc;
+}
+
+.project-meta {
+  display: flex;
+  flex-direction: column;
+}
+
+.project-name {
+  font-weight: 700;
+}
+
+.project-date {
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.secondary-button {
+  background: #ef4444;
+}
+
+.status-text {
+  color: #ef4444;
+  margin-top: 0.5rem;
+}

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:4000',
+        changeOrigin: true,
+      },
+    },
+  },
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "fullstack-pilot-server",
+  "version": "1.0.0",
+  "main": "src/index.js",
+  "type": "module",
+  "scripts": {
+    "dev": "node --watch src/index.js",
+    "start": "node src/index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "mongoose": "^8.3.4",
+    "morgan": "^1.10.0"
+  }
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,0 +1,64 @@
+import express from 'express';
+import mongoose from 'mongoose';
+import cors from 'cors';
+import morgan from 'morgan';
+
+const app = express();
+const PORT = process.env.PORT || 4000;
+const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/fullstack-pilot';
+
+app.use(cors());
+app.use(express.json());
+app.use(morgan('dev'));
+
+const projectSchema = new mongoose.Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+  },
+  { timestamps: true }
+);
+
+const Project = mongoose.model('Project', projectSchema);
+
+app.get('/api/projects', async (_req, res) => {
+  const projects = await Project.find().sort({ createdAt: -1 });
+  res.json(projects);
+});
+
+app.post('/api/projects', async (req, res) => {
+  const { name } = req.body;
+  if (!name || !name.trim()) {
+    return res.status(400).json({ error: 'Project name is required.' });
+  }
+
+  const project = await Project.create({ name: name.trim() });
+  res.status(201).json(project);
+});
+
+app.delete('/api/projects/:id', async (req, res) => {
+  const { id } = req.params;
+  const project = await Project.findByIdAndDelete(id);
+  if (!project) {
+    return res.status(404).json({ error: 'Project not found.' });
+  }
+  res.status(204).send();
+});
+
+async function start() {
+  try {
+    await mongoose.connect(MONGODB_URI);
+    console.log('Connected to MongoDB');
+    app.listen(PORT, () => {
+      console.log(`Server listening on http://localhost:${PORT}`);
+    });
+  } catch (error) {
+    console.error('Failed to start server:', error);
+    process.exit(1);
+  }
+}
+
+start();


### PR DESCRIPTION
## Summary
- add Express + Mongoose API for creating, listing, and deleting projects
- scaffold React UI via Vite that manages projects with create/remove actions
- document setup steps and API usage in the new root README

## Testing
- not run (npm registry access blocked in environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b1c7032cc8325b03fe71fa448c30e)