### PR TITLE
Rename project references to apps

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10,51 +10,57 @@ function formatDate(value) {
 }
 
 export default function App() {
-  const [projects, setProjects] = useState([]);
+  const [apps, setApps] = useState([]);
   const [name, setName] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
-  async function loadProjects() {
+  async function loadApps() {
     try {
       setLoading(true);
-      const { data } = await api.get('/projects');
-      setProjects(data);
+      const { data } = await api.get('/apps');
+      setApps(data);
     } catch (err) {
-      setError(err?.response?.data?.error || 'Could not load projects');
+      setError(err?.response?.data?.error || 'Could not load apps');
     } finally {
       setLoading(false);
     }
   }
 
-  async function addProject(event) {
+  async function addApp(event) {
     event.preventDefault();
     if (!name.trim()) return;
 
     try {
       setLoading(true);
-      const { data } = await api.post('/projects', { name: name.trim() });
-      setProjects((prev) => [data, ...prev]);
+      const { data } = await api.post('/apps', { name: name.trim() });
+      setApps((prev) => [data, ...prev]);
       setName('');
       setError('');
     } catch (err) {
-      setError(err?.response?.data?.error || 'Could not create project');
+      setError(err?.response?.data?.error || 'Could not create app');
     } finally {
       setLoading(false);
     }
   }
 
-  async function removeProject(id) {
+  async function removeApp(app) {
+    const confirmed = window.confirm(
+      `Are you sure you want to delete "${app.name}"? This action cannot be undone.`
+    );
+
+    if (!confirmed) return;
+
     try {
-      await api.delete(`/projects/${id}`);
-      setProjects((prev) => prev.filter((project) => project._id !== id));
+      await api.delete(`/apps/${app._id}`);
+      setApps((prev) => prev.filter((item) => item._id !== app._id));
     } catch (err) {
-      setError(err?.response?.data?.error || 'Could not remove project');
+      setError(err?.response?.data?.error || 'Could not remove app');
     }
   }
 
   useEffect(() => {
-    loadProjects();
+    loadApps();
   }, []);
 
   return (
@@ -63,43 +69,43 @@ export default function App() {
         <div className="logo" aria-hidden="true" />
         <div>
           <p style={{ margin: 0, color: '#475569' }}>FullStack Pilot</p>
-          <h1>Project Manager</h1>
+          <h1>App Manager</h1>
         </div>
       </header>
 
       <div className="card">
-        <form className="form-row" onSubmit={addProject}>
+        <form className="form-row" onSubmit={addApp}>
           <input
             type="text"
-            name="projectName"
-            placeholder="Enter a project name"
+            name="appName"
+            placeholder="Enter an app name"
             value={name}
             onChange={(event) => setName(event.target.value)}
             disabled={loading}
-            aria-label="Project name"
+            aria-label="App name"
           />
           <button type="submit" disabled={loading || !name.trim()}>
-            Add project
+            Add app
           </button>
         </form>
 
         {error && <p className="status-text">{error}</p>}
 
-        <div className="projects-list" aria-live="polite">
-          {projects.length === 0 && !loading && <p>No projects yet.</p>}
+        <div className="apps-list" aria-live="polite">
+          {apps.length === 0 && !loading && <p>No apps yet.</p>}
 
-          {projects.map((project) => (
-            <article key={project._id} className="project-item">
-              <div className="project-meta">
-                <span className="project-name">{project.name}</span>
-                <span className="project-date">Created {formatDate(project.createdAt)}</span>
+          {apps.map((app) => (
+            <article key={app._id} className="app-item">
+              <div className="app-meta">
+                <span className="app-name">{app.name}</span>
+                <span className="app-date">Created {formatDate(app.createdAt)}</span>
               </div>
               <button
                 type="button"
                 className="secondary-button"
-                onClick={() => removeProject(project._id)}
+                onClick={() => removeApp(app)}
               >
-                Remove
+                Remove app
               </button>
             </article>
           ))}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -72,12 +72,12 @@ button:disabled {
   cursor: not-allowed;
 }
 
-.projects-list {
+.apps-list {
   display: grid;
   gap: 0.75rem;
 }
 
-.project-item {
+.app-item {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -87,16 +87,16 @@ button:disabled {
   background: #f8fafc;
 }
 
-.project-meta {
+.app-meta {
   display: flex;
   flex-direction: column;
 }
 
-.project-name {
+.app-name {
   font-weight: 700;
 }
 
-.project-date {
+.app-date {
   font-size: 0.85rem;
   color: #475569;
 }

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -35,7 +35,7 @@ app.use(cors());
 app.use(express.json());
 app.use(morgan('dev'));
 
-const projectSchema = new mongoose.Schema(
+const appSchema = new mongoose.Schema(
   {
     name: {
       type: String,
@@ -46,7 +46,7 @@ const projectSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-const Project = mongoose.model('Project', projectSchema);
+const App = mongoose.model('App', appSchema);
 
 const asyncHandler = (handler) => async (req, res, next) => {
   try {
@@ -57,33 +57,33 @@ const asyncHandler = (handler) => async (req, res, next) => {
 };
 
 app.get(
-  '/api/projects',
+  '/api/apps',
   asyncHandler(async (_req, res) => {
-    const projects = await Project.find().sort({ createdAt: -1 });
-    res.json(projects);
+    const apps = await App.find().sort({ createdAt: -1 });
+    res.json(apps);
   })
 );
 
 app.post(
-  '/api/projects',
+  '/api/apps',
   asyncHandler(async (req, res) => {
     const { name } = req.body;
     if (!name || !name.trim()) {
-      return res.status(400).json({ error: 'Project name is required.' });
+      return res.status(400).json({ error: 'App name is required.' });
     }
 
-    const project = await Project.create({ name: name.trim() });
-    res.status(201).json(project);
+    const appRecord = await App.create({ name: name.trim() });
+    res.status(201).json(appRecord);
   })
 );
 
 app.delete(
-  '/api/projects/:id',
+  '/api/apps/:id',
   asyncHandler(async (req, res) => {
     const { id } = req.params;
-    const project = await Project.findByIdAndDelete(id);
-    if (!project) {
-      return res.status(404).json({ error: 'Project not found.' });
+    const appRecord = await App.findByIdAndDelete(id);
+    if (!appRecord) {
+      return res.status(404).json({ error: 'App not found.' });
     }
     res.status(204).send();
   })


### PR DESCRIPTION
## Summary
- rename client state, handlers, and markup to use app terminology exclusively
- update API routes, model naming, and styles to align with app naming

## Testing
- npm test *(fails: Missing script "test")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b2c43c70483258f81f1bef3038150)