### PR TITLE
Add frontend tests to CI workflow

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -23,6 +23,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: client
+
+      - name: Run frontend tests
+        run: npm test
+        working-directory: client
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
## Summary
- set up Node.js and install client dependencies in the frontend pipeline
- run frontend unit tests before building and pushing the Docker image

## Testing
- Not run (npm registry access blocked in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c8c1f4d78832583065a7e9d756b36)