### PR TITLE
Add architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ A minimal full-stack starter that pairs a React frontend with a Node.js + MongoD
   - `services-service/` – Standalone Flask API with in-memory CRUD endpoints.
   - `dependancies-service/` – NET 8 Web API (controllers) exposing CRUD endpoints with in-memory storage.
 
+See `docs/ARCHITECTURE.md` for a high-level diagram of how the client, services, database, and CI/CD pieces fit together.
+
 ## Getting started
 
 ### 1) Install dependencies

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,35 @@
+# Architecture Overview
+
+```mermaid
+flowchart TD
+    Developer((Source)) --> CI[CI/CD Pipeline]
+    CI --> Tests[Unit/Integration Tests]
+    Tests --> Build[Build & Package]
+    Build --> Registry[(Artifact Registry)]
+    Registry --> Deploy[Deploy to Runtime]
+
+    subgraph Runtime
+        Client[React Client]
+        subgraph Services
+            AppsService["Apps Service\n(Node.js)"]
+            DotNetService["Dependencies Service\n(.NET)"]
+            PythonService["CRUD Service\n(Python Flask)"]
+        end
+        Mongo[(MongoDB)]
+    end
+
+    Deploy --> Client
+    Deploy --> Services
+
+    Client -->|API calls /api/projects| AppsService
+    Client -->|CRUD /api/dependancies| DotNetService
+    Client -->|CRUD /api| PythonService
+
+    AppsService -->|Project data| Mongo
+    DotNetService -->|In-memory storage| DotNetService
+    PythonService -->|In-memory CRUD| PythonService
+
+    CI -. optional migrations .-> Mongo
+```
+
+The diagram highlights how the React client communicates with independently deployable backend services, with the Node.js apps service persisting project data in MongoDB. CI/CD automates testing, packaging, and deployment of the client and services to a shared runtime environment.


### PR DESCRIPTION
## Summary
- add a dedicated architecture overview with a Mermaid diagram
- link the main README to the new diagram for quick discovery

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d7b350db88325a49a646f453a0337)