### PR TITLE
Enhance issue templates with impact and acceptance criteria

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,6 +29,15 @@ body:
       required: true
 
   - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Describe the concrete effects (e.g., blocked flows, data risk, performance degradation).
+      placeholder: e.g., "Checkout blocked for all mobile users; 500 error after submitting payment."
+    validations:
+      required: true
+
+  - type: textarea
     id: steps
     attributes:
       label: Steps to reproduce
@@ -55,3 +64,15 @@ body:
       render: shell
     validations:
       required: false
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: Provide measurable, binary conditions to mark this issue complete.
+      value: |-
+        - [ ] Reproduction steps succeed without errors across supported environments
+        - [ ] Related logs show no unhandled exceptions for this path
+        - [ ] Regression coverage added for the fixed path
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/new_feature.yml
+++ b/.github/ISSUE_TEMPLATE/new_feature.yml
@@ -29,6 +29,15 @@ body:
       required: true
 
   - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Describe the concrete effects this feature will have (users, systems, performance, risks reduced).
+      placeholder: e.g., "Reduces checkout drop-off by adding wallet support for mobile web users."
+    validations:
+      required: true
+
+  - type: textarea
     id: alternative
     attributes:
       label: Considered alternatives
@@ -36,15 +45,14 @@ body:
     validations:
       required: false
 
-  - type: dropdown
-    id: impact
+  - type: textarea
+    id: acceptance_criteria
     attributes:
-      label: Impact level
-      description: Importance or urgency of the feature
-      options:
-        - Low
-        - Medium
-        - High
-        - Critical
+      label: Acceptance criteria
+      description: Provide measurable, binary conditions to mark this issue complete.
+      value: |-
+        - [ ] The proposed behavior is available behind an appropriate guard/flag if needed
+        - [ ] User-facing scenarios succeed across supported environments
+        - [ ] Metrics/telemetry confirm the intended impact or baseline is captured
     validations:
-      required: false
+      required: true


### PR DESCRIPTION
## Summary
- add concrete impact sections to bug and feature request templates
- include measurable acceptance criteria checklists for each template
- normalize template structure to encourage evaluable architectural thinking

## Testing
- not run (issue template changes only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d7bd103b083258320638b6618f67e)