### PR TITLE
Fix discover services script for ESM compatibility

### DIFF
--- a/.devops/discover-services.js
+++ b/.devops/discover-services.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const path = require('path');
-const { execSync } = require('child_process');
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
 
 const [outputFile, baseShaArg, headShaArg, servicesDirArg = 'services', workflowPathArg = '.github/workflows/build-backend.yml'] = process.argv.slice(2);
 


### PR DESCRIPTION
## Summary
- convert discover-services script to ES module imports to align with repository configuration

## Testing
- node .devops/discover-services.js /tmp/services.out "" ""

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dea68081c8325bf21c914488d6e64)