### PR TITLE
Add ESLint setup and CI linting for client

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -33,6 +33,10 @@ jobs:
         run: npm install
         working-directory: client
 
+      - name: Run frontend lint
+        run: npm run lint
+        working-directory: client
+
       - name: Run frontend tests
         run: npm test
         working-directory: client

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -1,0 +1,27 @@
+import js from '@eslint/js';
+import globals from 'globals';
+
+export default [
+  {
+    ignores: ['dist/**'],
+  },
+  {
+    files: ['**/*.{js,jsx,ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'module',
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      'no-unused-vars': 'off',
+      'no-undef': 'off',
+    },
+  },
+];

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "lint": "eslint ."
   },
   "dependencies": {
     "axios": "^1.6.8",


### PR DESCRIPTION
## Summary
- add a basic ESLint flat config for the client project and lint script
- run the new lint step in the frontend build workflow

## Testing
- npm run lint
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dee59bbd883259cc7007df099f381)