### PR TITLE
Require internal token for apps-service /internal/logs/recent in production; add config and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ POSTGRES_PASSWORD=fullstack
 # Agent service internal auth token for POST /pr-description.
 # Used by docker-compose and smoke tests.
 AGENT_SERVICE_TOKEN=dev-agent-token
+
+# Apps service internal auth token for GET /internal/logs/recent.
+# Required by docker-compose for apps-service.
+INTERNAL_LOGS_TOKEN=dev-internal-logs-token

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -38,6 +38,7 @@ jobs:
           MSSQL_SA_PASSWORD: CiSmoke_Strong!Passw0rd1
           POSTGRES_USER: fullstack
           POSTGRES_PASSWORD: fullstack
+          INTERNAL_LOGS_TOKEN: ci-internal-logs-token
         run: |
           docker compose up -d --build
 
@@ -56,6 +57,7 @@ jobs:
           MSSQL_SA_PASSWORD: CiSmoke_Strong!Passw0rd1
           POSTGRES_USER: fullstack
           POSTGRES_PASSWORD: fullstack
+          INTERNAL_LOGS_TOKEN: ci-internal-logs-token
         run: |
           docker compose ps
           docker compose logs
@@ -66,4 +68,5 @@ jobs:
           MSSQL_SA_PASSWORD: CiSmoke_Strong!Passw0rd1
           POSTGRES_USER: fullstack
           POSTGRES_PASSWORD: fullstack
+          INTERNAL_LOGS_TOKEN: ci-internal-logs-token
         run: docker compose down --volumes

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ For Docker Compose runs, define local secrets in a root `.env` file (not committ
    - `MSSQL_SA_PASSWORD` (required, strong password for SQL Server)
    - `POSTGRES_USER` and `POSTGRES_PASSWORD` (required by PostgreSQL and Flask service)
    - `AGENT_SERVICE_TOKEN` (recommended; defaults to `dev-agent-token` if unset in local compose)
+   - `INTERNAL_LOGS_TOKEN` (required by apps-service in compose for `/internal/logs/recent`)
 3. Start the stack: `docker compose up --build`
 
 > `docker-compose.yml` intentionally fails fast when these variables are missing, to avoid weak/default credentials in clear text.
@@ -218,6 +219,14 @@ Default response shape:
   - `uptime`: process uptime in seconds.
   - `timestamp`: ISO-8601 server timestamp when the check was generated.
 - **Use case:** liveness probe and load balancer target health verification.
+
+### apps-service internal logs endpoint protection
+- **Endpoint:** `GET http://localhost:4000/internal/logs/recent`
+- **Environment variables:**
+  - `INTERNAL_LOGS_TOKEN` (recommended in all environments, required in compose): expected value for header `x-internal-token`.
+  - `INTERNAL_LOGS_ALLOW_NON_PROD` (optional, default `true`): when `true`, non-production environments can access this endpoint without a token.
+- **Production behavior:** with `NODE_ENV=production`, access requires a valid `x-internal-token`; if token config is missing, endpoint returns `403`.
+- **Error responses:** returns explicit JSON with `401 unauthorized` for missing/invalid header, or `403 forbidden` when endpoint is blocked by policy.
 - **Local test:**
   - `curl -s http://localhost:4000/healthz`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,10 @@ services:
     container_name: fullstack-pilot-apps-service
     environment:
       PORT: 4000
+      NODE_ENV: production
       MONGODB_URI: mongodb://mongo:27017/fullstack-pilot
+      INTERNAL_LOGS_TOKEN: ${INTERNAL_LOGS_TOKEN:?INTERNAL_LOGS_TOKEN is required (set it in .env)}
+      INTERNAL_LOGS_ALLOW_NON_PROD: "false"
     depends_on:
       - mongo
     ports:

--- a/services/apps-service/src/app.js
+++ b/services/apps-service/src/app.js
@@ -5,8 +5,15 @@ import { getActiveServices } from './servicesResolver.js';
 import { logger } from './logger.js';
 import { getRecentRequestEvents } from './logStore.js';
 
-export function createApp({ serviceName, serviceBasePath }) {
+export function createApp({
+  serviceName,
+  serviceBasePath,
+  nodeEnv = 'development',
+  internalLogsToken,
+  internalLogsAllowNonProd = true,
+}) {
   const app = express();
+  const isProduction = nodeEnv === 'production';
 
   app.use(cors());
   app.use(express.json());
@@ -21,6 +28,28 @@ export function createApp({ serviceName, serviceBasePath }) {
   });
 
   app.get('/internal/logs/recent', (req, res) => {
+    const providedToken = req.header('x-internal-token');
+
+    if (!isProduction && internalLogsAllowNonProd) {
+      // Allow local/dev observability by default outside production.
+    } else if (!internalLogsToken) {
+      return res.status(403).json({
+        error: 'forbidden',
+        message:
+          'Access to /internal/logs/recent is disabled because INTERNAL_LOGS_TOKEN is not configured.',
+      });
+    } else if (!providedToken) {
+      return res.status(401).json({
+        error: 'unauthorized',
+        message: 'Missing x-internal-token header.',
+      });
+    } else if (providedToken !== internalLogsToken) {
+      return res.status(401).json({
+        error: 'unauthorized',
+        message: 'Invalid internal token.',
+      });
+    }
+
     const limit = Number(req.query.limit || 100);
     const events = getRecentRequestEvents(limit);
 

--- a/services/apps-service/src/env.js
+++ b/services/apps-service/src/env.js
@@ -30,10 +30,19 @@ export function loadEnvironment() {
 }
 
 export function getConfig() {
+  const internalLogsAllowNonProdRaw = process.env.INTERNAL_LOGS_ALLOW_NON_PROD;
+  const internalLogsAllowNonProd =
+    internalLogsAllowNonProdRaw == null
+      ? true
+      : ['1', 'true', 'yes', 'on'].includes(internalLogsAllowNonProdRaw.trim().toLowerCase());
+
   return {
     port: process.env.PORT || 4000,
     mongodbUri: (process.env.MONGODB_URI || DEFAULT_MONGODB_URI).trim(),
     serviceName: process.env.SERVICE_NAME || process.env.SERVICE,
     serviceBasePath: process.env.SERVICE_BASE_PATH,
+    nodeEnv: process.env.NODE_ENV || 'development',
+    internalLogsToken: process.env.INTERNAL_LOGS_TOKEN?.trim(),
+    internalLogsAllowNonProd,
   };
 }

--- a/services/apps-service/src/startup.js
+++ b/services/apps-service/src/startup.js
@@ -36,7 +36,15 @@ function closeHttpServer(server) {
 }
 
 export async function startServer(
-  { port, mongodbUri, serviceName, serviceBasePath },
+  {
+    port,
+    mongodbUri,
+    serviceName,
+    serviceBasePath,
+    nodeEnv,
+    internalLogsToken,
+    internalLogsAllowNonProd,
+  },
   {
     mongooseConnect = mongoose.connect.bind(mongoose),
     mongooseConnection = mongoose.connection,
@@ -48,7 +56,13 @@ export async function startServer(
     shutdownTimeoutMs = SHUTDOWN_TIMEOUT_MS,
   } = {}
 ) {
-  const app = appFactory({ serviceName, serviceBasePath });
+  const app = appFactory({
+    serviceName,
+    serviceBasePath,
+    nodeEnv,
+    internalLogsToken,
+    internalLogsAllowNonProd,
+  });
   let server;
 
   try {

--- a/services/apps-service/tests/internalLogsAuth.test.js
+++ b/services/apps-service/tests/internalLogsAuth.test.js
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+
+import { createApp } from '../src/app.js';
+
+const serversToClose = [];
+
+afterEach(async () => {
+  await Promise.all(
+    serversToClose.splice(0, serversToClose.length).map(
+      (server) => new Promise((resolve) => server.close(resolve))
+    )
+  );
+});
+
+async function requestInternalLogs(appOptions = {}, headers = {}) {
+  const app = createApp(appOptions);
+  const server = app.listen(0);
+  serversToClose.push(server);
+
+  await new Promise((resolve) => server.once('listening', resolve));
+  const { port } = server.address();
+
+  return fetch(`http://127.0.0.1:${port}/internal/logs/recent`, {
+    headers,
+  });
+}
+
+describe('GET /internal/logs/recent auth', () => {
+  it('allows access in non-production when INTERNAL_LOGS_ALLOW_NON_PROD is enabled', async () => {
+    const response = await requestInternalLogs({
+      nodeEnv: 'development',
+      internalLogsAllowNonProd: true,
+    });
+
+    assert.equal(response.status, 200);
+  });
+
+  it('returns 403 in production when INTERNAL_LOGS_TOKEN is not configured', async () => {
+    const response = await requestInternalLogs({
+      nodeEnv: 'production',
+      internalLogsAllowNonProd: false,
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.equal(body.error, 'forbidden');
+    assert.match(body.message, /INTERNAL_LOGS_TOKEN/);
+  });
+
+  it('returns 401 in production when token header is missing', async () => {
+    const response = await requestInternalLogs({
+      nodeEnv: 'production',
+      internalLogsToken: 'internal-secret',
+      internalLogsAllowNonProd: false,
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(body.error, 'unauthorized');
+    assert.match(body.message, /Missing x-internal-token/i);
+  });
+
+  it('returns 401 in production when token header is invalid', async () => {
+    const response = await requestInternalLogs(
+      {
+        nodeEnv: 'production',
+        internalLogsToken: 'internal-secret',
+        internalLogsAllowNonProd: false,
+      },
+      { 'x-internal-token': 'wrong-token' }
+    );
+    const body = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(body.error, 'unauthorized');
+    assert.match(body.message, /Invalid internal token/i);
+  });
+
+  it('returns 200 in production when token header is valid', async () => {
+    const response = await requestInternalLogs(
+      {
+        nodeEnv: 'production',
+        internalLogsToken: 'internal-secret',
+        internalLogsAllowNonProd: false,
+      },
+      { 'x-internal-token': 'internal-secret' }
+    );
+
+    assert.equal(response.status, 200);
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent accidental public access to the apps-service internal logs endpoint by requiring a secret token in production and providing sensible default behavior in non-production.

### Description
- Added `INTERNAL_LOGS_TOKEN` to `.env.example` and documented the variable and endpoint protection in `README.md`.
- Enforced token-based access in `services/apps-service` by extending `createApp` to accept `nodeEnv`, `internalLogsToken`, and `internalLogsAllowNonProd`, and implementing authentication/authorization logic for `GET /internal/logs/recent` with clear `401/403` JSON responses.
- Wired environment flags through `services/apps-service/src/env.js` and `startup.js`, and updated `docker-compose.yml` to set `NODE_ENV=production`, require `INTERNAL_LOGS_TOKEN`, and disable non-prod access in compose runs.
- Added unit tests `services/apps-service/tests/internalLogsAuth.test.js` covering non-production allow, missing token config, missing header, invalid header, and valid header scenarios.

### Testing
- Ran the `services/apps-service` unit test suite which includes `internalLogsAuth.test.js`, and the tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf1ff82fbc8325982ca97ba544a911)