### PR TITLE
Expand root test:all to run services-service, dependencies-service, and agent-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,25 @@ Default response shape:
 - **Local test:**
   - `curl -s http://localhost:5000/healthz`
 
+
+
+## Test prerequisites
+Run `npm run init` first so Node dependencies are installed for the repository and services.
+
+`npm run test:all` now executes these commands in sequence:
+- `npm run test:apps-service` (Node.js tests in `services/apps-service`)
+- `npm run test:services-service` (Python `unittest` tests in `services/services-service/tests`)
+- `npm run test:dependencies-service` (.NET tests/build validation via `dotnet test` in `services/dependencies-service`)
+- `npm run test:agent-service` (Node.js tests in `services/agent-service`)
+- `npm run test:client` (frontend tests)
+
+Additional local prerequisites for deterministic runs:
+- Python 3.10+ available as `python` for `services-service` tests.
+- .NET 8 SDK available on PATH for `dependencies-service` tests.
+- Node.js 18+ for Node-based services and frontend tests.
+
 ## Project conventions
 - **Naming/layout:** backend services live under `services/<name>-service` with their own `package.json` (or equivalent) and Dockerfile; the React app lives in `client/`.
 - **Environment:** each service reads from a local `.env` file when present (e.g., `PORT`, `MONGODB_URI`, `POSTGRES_DSN`, `ASPNETCORE_URLS`, `ConnectionStrings__DependenciesDb`).
 - **Adding a service:** create `services/<new-service>`, include a runnable dev script (`npm run dev` or `start`), add a Dockerfile, expose a unique port, and wire it into `docker-compose.yml` (and `.devops` manifests if you want GitOps support).
-- **Scripts to know:** `npm run init` installs all service/client dependencies; `npm run start:services` starts every service that has a `dev`/`start` script; smoke tests live under `.devops/tests/smoke/`.
+- **Scripts to know:** `npm run init` installs all service/client dependencies; `npm run start:services` starts every service that has a `dev`/`start` script; smoke tests live under `.devops/tests/smoke/`; `npm run test:all` runs the client plus all service test commands.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fullstack-pilot",
   "version": "0.0.0",
-  "description": "Here’s a README template for **FullStack Pilot** in English:",
+  "description": "Here\u2019s a README template for **FullStack Pilot** in English:",
   "main": "index.js",
   "type": "module",
   "scripts": {
@@ -12,8 +12,11 @@
     "init:client": "cd client && npm install",
     "test:smoke": "node .devops/tests/smoke/run-smoke-tests.js",
     "test:apps-service": "cd services/apps-service && npm test",
+    "test:services-service": "npm --prefix services/services-service test",
+    "test:dependencies-service": "npm --prefix services/dependencies-service test",
+    "test:agent-service": "npm --prefix services/agent-service test",
     "test:client": "cd client && npm test",
-    "test:all": "npm run test:apps-service && npm run test:client",
+    "test:all": "npm run test:apps-service && npm run test:services-service && npm run test:dependencies-service && npm run test:agent-service && npm run test:client",
     "start:apps-service": "cd services/apps-service && npm run dev",
     "start:client": "cd client && npm run dev",
     "start:services": "node .devops/start-all-services.js",

--- a/services/dependencies-service/package.json
+++ b/services/dependencies-service/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "dependencies-service",
+  "private": true,
+  "scripts": {
+    "test": "dotnet test --nologo --verbosity minimal"
+  }
+}

--- a/services/services-service/package.json
+++ b/services/services-service/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "services-service",
+  "private": true,
+  "scripts": {
+    "test": "python -m unittest discover -s tests -p 'test_*.py'"
+  }
+}


### PR DESCRIPTION
### Motivation
- Ensure `npm run test:all` runs the full repository test matrix (Flask, .NET, Node, and client) so CI/QA can validate all services in a single command.
- Make per-service test entrypoints deterministic and runnable in CI by adding minimal, language-appropriate `test` scripts inside each service.

### Description
- Added root npm scripts in `package.json`: `test:services-service`, `test:dependencies-service`, and `test:agent-service`, and updated `test:all` to chain all service and client tests in sequence.
- Created `services/services-service/package.json` with a deterministic Python test command: `python -m unittest discover -s tests -p 'test_*.py'`.
- Created `services/dependencies-service/package.json` with a deterministic .NET test command: `dotnet test --nologo --verbosity minimal`.
- Documented test prerequisites and the `npm run test:all` composition in `README.md`.

### Testing
- Ran `npm run test:all` which executed the chained commands; `apps-service`, `services-service`, `agent-service`, and `client` test suites passed, while `dependencies-service` failed to run because `dotnet` is not available in this environment (`sh: 1: dotnet: not found`).
- Ran `npm run test:agent-service` which passed all agent tests (15 tests passing).
- Ran `npm run test:client` which passed the frontend test suite (9 files, 26 tests passing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf2477b6e4832586d003f8302af32b)