### PR TITLE
docs: align Markdown API routes and GitOps bootstrap paths

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -18,4 +18,4 @@ npm run dev -- --host
 
 ## Notes
 - Environment variables come from `vite.config.js` and `.env` files (see Vite docs for prefixes). When running via Docker Compose the proxy is preconfigured.
-- The UI consumes the Node API at `/api/projects` and can be extended to call the optional Flask and .NET services.
+- The UI consumes the Node API at `/api/apps` and can be extended to call the optional Flask and .NET services.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,9 +23,9 @@ flowchart TD
     Deploy --> Client
     Deploy --> Services
 
-    Client -->|API calls /api/projects| AppsService
+    Client -->|API calls /api/apps| AppsService
     Client -->|CRUD /api/dependencies| DotNetService
-    Client -->|CRUD /api| PythonService
+    Client -->|CRUD /api/services| PythonService
 
     AppsService -->|Project data| Mongo
     DotNetService -->|Dependencies data| MSSQL

--- a/services/README.md
+++ b/services/README.md
@@ -5,13 +5,13 @@ Each folder provides the deployment, service, and supporting resources for the c
 
 ## Bootstrap steps
 
-1. Apply the Argo CD Applications from the consolidated `deploy/gitops/` folder (added to match the repo's deployment asset layout):
+1. Apply the Argo CD Applications from the consolidated `.gitops/` folder:
    ```bash
-   kubectl apply -f deploy/gitops/server-application.yaml
-   kubectl apply -f deploy/gitops/client-application.yaml
-   kubectl apply -f deploy/gitops/apps-service-application.yaml
-   kubectl apply -f deploy/gitops/services-service-application.yaml
-   kubectl apply -f deploy/gitops/dependencies-service-application.yaml
+   kubectl apply -f .gitops/server-application.yaml
+   kubectl apply -f .gitops/client-application.yaml
+   kubectl apply -f .gitops/apps-service-application.yaml
+   kubectl apply -f .gitops/services-service-application.yaml
+   kubectl apply -f .gitops/dependencies-service-application.yaml
    ```
 2. Update the container image references as needed (for example via Kustomize image overrides or Argo CD parameters).
 3. Configure secrets such as `MONGODB_URI` with the values for your cluster before promoting beyond development.


### PR DESCRIPTION
### Motivation
- Fix several stale or inconsistent documentation references so markdown files reflect the actual API routes and repo layout.

### Description
- Update `client/README.md` to reference the actual Node endpoint (`/api/apps`).
- Update `docs/ARCHITECTURE.md` Mermaid diagram to use `/api/apps` and `/api/services`.
- Update `services/README.md` bootstrap instructions to point at the real `.gitops/` folder and files.

### Testing
- Ran a targeted stale-reference scan with `rg -n "/api/projects|deploy/gitops" client/README.md docs/ARCHITECTURE.md services/README.md` which returned no matches after the changes.
- Verified the commit and files with `git show` and prepared the PR; no unit or CI tests were executed in this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d089c701f08325992023198f0e5ec8)