### PR TITLE
Add versioned DB migrations for all services (Mongo, Postgres, SQL Server) and integrate startup hooks

### DIFF
--- a/.devops/tests/smoke/run-smoke-tests.js
+++ b/.devops/tests/smoke/run-smoke-tests.js
@@ -93,9 +93,33 @@ const services = [
   },
 ];
 
+function formatErrorDetails(error) {
+  const message = error?.message || String(error);
+  const cause = error?.cause?.message ? ` | cause: ${error.cause.message}` : '';
+  return `${message}${cause}`;
+}
+
 async function runHttpTest(url, validate, options) {
   const response = await fetchWithTimeout(url, options);
-  await validate(response);
+  const diagnosticResponse = response.clone();
+
+  try {
+    await validate(response);
+  } catch (error) {
+    let bodySnippet = '<unavailable>';
+
+    try {
+      const body = await diagnosticResponse.text();
+      bodySnippet = body ? body.slice(0, 500) : '<empty>';
+    } catch {
+      bodySnippet = '<failed to read body>';
+    }
+
+    throw new Error(
+      `${error.message} | url=${url} | status=${response.status} ${response.statusText} | body=${bodySnippet}`,
+      { cause: error },
+    );
+  }
 }
 
 async function fetchWithTimeout(url, options = {}) {
@@ -327,14 +351,15 @@ async function runTest({ name, run, setup }) {
       return;
     } catch (error) {
       lastError = error;
-      console.log('failed');
+      console.log(`failed (${formatErrorDetails(error)})`);
       if (attempt < retries) {
         await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
       }
     }
   }
 
-  throw new Error(`Smoke test failed for ${name}: ${lastError?.message || 'Unknown error'}`);
+  const details = lastError ? formatErrorDetails(lastError) : 'Unknown error';
+  throw new Error(`Smoke test failed for ${name}: ${details}`);
 }
 
 async function main() {
@@ -346,5 +371,8 @@ async function main() {
 
 main().catch((error) => {
   console.error(`\nSmoke test run failed: ${error.message}`);
+  if (error?.stack) {
+    console.error(error.stack);
+  }
   process.exit(1);
 });

--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ This repo intentionally splits responsibilities across independent services so e
 
 - **Visual:** the mermaid architecture diagram lives in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 
+
+## Database migrations
+Versioned migrations are used by all DB-backed backend services (`apps-service`, `services-service`, `dependencies-service`).
+See the dedicated workflow guide in [`docs/MIGRATIONS.md`](docs/MIGRATIONS.md).
+
 ## AI-Native Development
 
 This repository is built and maintained using AI agents (OpenAI Codex).  

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -1,0 +1,83 @@
+# Database migrations workflow
+
+This repository now uses versioned migrations for all database-backed backend services.
+No service should create or alter schema structures at runtime in application business code.
+
+## Services matrix
+
+- `services/services-service` (Python + PostgreSQL): Alembic
+- `services/dependencies-service` (.NET + SQL Server): EF Core Migrations
+- `services/apps-service` (Node.js + MongoDB): internal versioned migration runner
+
+---
+
+## Development workflow
+
+### Python (`services-service`)
+
+```bash
+cd services/services-service
+pip install -r requirements.txt
+alembic -c alembic.ini upgrade head
+python app.py
+```
+
+Create a new migration:
+
+```bash
+cd services/services-service
+alembic -c alembic.ini revision -m "describe change"
+```
+
+### .NET (`dependencies-service`)
+
+```bash
+cd services/dependencies-service
+dotnet restore
+dotnet ef database update
+dotnet run
+```
+
+Create a new migration:
+
+```bash
+cd services/dependencies-service
+dotnet ef migrations add <MigrationName>
+```
+
+At startup:
+- migrations are automatically applied in `Development`
+- outside `Development`, set `Database:MigrateOnStartup=true` to apply them automatically
+- set `Database:MigrateOnStartup=false` only when migrations are handled as a separate deployment step
+
+### Node.js (`apps-service`)
+
+```bash
+cd services/apps-service
+npm install
+npm run migrate:up
+npm run start
+```
+
+Create a new migration:
+
+```bash
+cd services/apps-service
+npm run migrate:create -- <migration-name>
+```
+
+At startup:
+- migrations run automatically when `NODE_ENV != production`
+- in production, set `MONGO_MIGRATE_ON_STARTUP=true` to run them at startup if desired
+
+---
+
+## Production guidance
+
+- Prefer running migrations as an explicit deployment step before rolling out new app versions.
+- Keep startup auto-migration as a controlled fallback.
+- Ensure one writer executes migrations at a time per service/database.
+- Rollback strategy:
+  - Alembic: `alembic downgrade <revision>`
+  - EF Core: `dotnet ef database update <MigrationName>`
+  - apps-service runner: `npm run migrate:down`

--- a/services/apps-service/Dockerfile
+++ b/services/apps-service/Dockerfile
@@ -3,6 +3,8 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install --omit=dev --ignore-scripts
 COPY src ./src
+COPY migrations ./migrations
+COPY scripts ./scripts
 ENV PORT=4000
 EXPOSE 4000
 CMD ["npm", "start"]

--- a/services/apps-service/migrations/20260403010000-initial-apps-collection.js
+++ b/services/apps-service/migrations/20260403010000-initial-apps-collection.js
@@ -1,0 +1,17 @@
+export const up = async (db) => {
+  const collections = await db.listCollections({ name: 'apps' }).toArray();
+  if (collections.length === 0) {
+    await db.createCollection('apps');
+  }
+
+  await db.collection('apps').createIndex({ createdAt: -1 });
+};
+
+export const down = async (db) => {
+  const collections = await db.listCollections({ name: 'apps' }).toArray();
+  if (collections.length === 0) {
+    return;
+  }
+
+  await db.dropCollection('apps');
+};

--- a/services/apps-service/package.json
+++ b/services/apps-service/package.json
@@ -7,7 +7,11 @@
     "dev": "node --watch src/index.js",
     "start": "node src/index.js",
     "start:apps": "SERVICE_NAME=apps SERVICE_BASE_PATH=/ node src/index.js",
-    "test": "node --test"
+    "test": "node --test",
+    "migrate:create": "node scripts/migrate.js create",
+    "migrate:up": "node scripts/migrate.js up",
+    "migrate:down": "node scripts/migrate.js down",
+    "migrate:status": "node scripts/migrate.js status"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/services/apps-service/scripts/migrate.js
+++ b/services/apps-service/scripts/migrate.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import {
+  createMigrationTemplate,
+  getMigrationStatus,
+  runMigrationsDown,
+  runMigrationsUp,
+} from '../src/migrationsRunner.js';
+
+const [, , command, ...args] = process.argv;
+
+async function main() {
+  switch (command) {
+    case 'up':
+      await runMigrationsUp();
+      console.log('Mongo migrations applied.');
+      break;
+    case 'down': {
+      const reverted = await runMigrationsDown();
+      console.log(reverted ? `Mongo migration reverted: ${reverted}` : 'No migration to revert.');
+      break;
+    }
+    case 'status': {
+      const status = await getMigrationStatus();
+      for (const item of status) {
+        console.log(`${item.applied ? '[x]' : '[ ]'} ${item.id}`);
+      }
+      break;
+    }
+    case 'create': {
+      const migrationName = args.join(' ');
+      const fileName = await createMigrationTemplate(migrationName);
+      console.log(`Created migration: ${fileName}`);
+      break;
+    }
+    default:
+      console.error('Usage: node scripts/migrate.js <up|down|status|create> [migration-name]');
+      process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/services/apps-service/src/index.js
+++ b/services/apps-service/src/index.js
@@ -3,11 +3,22 @@ import { startServer } from './startup.js';
 
 loadEnvironment();
 
-const { port, mongodbUri, serviceName, serviceBasePath } = getConfig();
+const {
+  port,
+  mongodbUri,
+  serviceName,
+  serviceBasePath,
+  nodeEnv,
+  internalLogsToken,
+  internalLogsAllowNonProd,
+} = getConfig();
 
 startServer({
   port,
   mongodbUri,
   serviceName,
   serviceBasePath,
+  nodeEnv,
+  internalLogsToken,
+  internalLogsAllowNonProd,
 });

--- a/services/apps-service/src/migrations.js
+++ b/services/apps-service/src/migrations.js
@@ -1,0 +1,14 @@
+import { runMigrationsUp } from './migrationsRunner.js';
+
+export function shouldRunMigrations(nodeEnv) {
+  const explicit = process.env.MONGO_MIGRATE_ON_STARTUP;
+  if (explicit != null) {
+    return explicit === 'true';
+  }
+
+  return nodeEnv !== 'production';
+}
+
+export async function runMongoMigrations() {
+  await runMigrationsUp();
+}

--- a/services/apps-service/src/migrationsRunner.js
+++ b/services/apps-service/src/migrationsRunner.js
@@ -1,0 +1,121 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import mongoose from 'mongoose';
+
+const CHANGELOG_COLLECTION = 'schema_migrations';
+const DEFAULT_MONGODB_URI = 'mongodb://localhost:27017/fullstack-pilot';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MIGRATIONS_DIR = path.resolve(__dirname, '../migrations');
+
+async function ensureChangelog(db) {
+  await db.collection(CHANGELOG_COLLECTION).createIndex({ id: 1 }, { unique: true });
+}
+
+async function listMigrationFiles() {
+  const entries = await fs.readdir(MIGRATIONS_DIR, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.js'))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+async function loadMigration(fileName) {
+  const migrationUrl = pathToFileURL(path.resolve(MIGRATIONS_DIR, fileName)).href;
+  return import(migrationUrl);
+}
+
+async function getAppliedMigrationIds(db) {
+  const rows = await db.collection(CHANGELOG_COLLECTION).find({}, { projection: { id: 1 } }).sort({ id: 1 }).toArray();
+  return rows.map((row) => row.id);
+}
+
+export async function runMigrationsUp(mongodbUri = process.env.MONGODB_URI || DEFAULT_MONGODB_URI) {
+  const connection = await mongoose.createConnection(mongodbUri).asPromise();
+
+  try {
+    const db = connection.db;
+    await ensureChangelog(db);
+
+    const [files, appliedIds] = await Promise.all([listMigrationFiles(), getAppliedMigrationIds(db)]);
+    const appliedSet = new Set(appliedIds);
+
+    for (const file of files) {
+      if (appliedSet.has(file)) {
+        continue;
+      }
+
+      const migration = await loadMigration(file);
+      await migration.up(db);
+      await db.collection(CHANGELOG_COLLECTION).insertOne({ id: file, appliedAt: new Date() });
+    }
+  } finally {
+    await connection.close();
+  }
+}
+
+export async function runMigrationsDown(mongodbUri = process.env.MONGODB_URI || DEFAULT_MONGODB_URI) {
+  const connection = await mongoose.createConnection(mongodbUri).asPromise();
+
+  try {
+    const db = connection.db;
+    await ensureChangelog(db);
+
+    const lastApplied = await db
+      .collection(CHANGELOG_COLLECTION)
+      .find({}, { projection: { id: 1 } })
+      .sort({ appliedAt: -1 })
+      .limit(1)
+      .next();
+
+    if (!lastApplied) {
+      return null;
+    }
+
+    const migration = await loadMigration(lastApplied.id);
+    await migration.down(db);
+    await db.collection(CHANGELOG_COLLECTION).deleteOne({ id: lastApplied.id });
+    return lastApplied.id;
+  } finally {
+    await connection.close();
+  }
+}
+
+export async function getMigrationStatus(mongodbUri = process.env.MONGODB_URI || DEFAULT_MONGODB_URI) {
+  const connection = await mongoose.createConnection(mongodbUri).asPromise();
+
+  try {
+    const db = connection.db;
+    await ensureChangelog(db);
+
+    const [files, appliedIds] = await Promise.all([listMigrationFiles(), getAppliedMigrationIds(db)]);
+    const appliedSet = new Set(appliedIds);
+
+    return files.map((file) => ({ id: file, applied: appliedSet.has(file) }));
+  } finally {
+    await connection.close();
+  }
+}
+
+export async function createMigrationTemplate(name) {
+  if (!name) {
+    throw new Error('A migration name is required.');
+  }
+
+  const normalizedName = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  const timestamp = new Date().toISOString().replace(/[-:TZ.]/g, '').slice(0, 14);
+  const fileName = `${timestamp}-${normalizedName || 'migration'}.js`;
+  const targetPath = path.resolve(MIGRATIONS_DIR, fileName);
+  const template = `export const up = async (db) => {\n  // implement migration\n};\n\nexport const down = async (db) => {\n  // implement rollback\n};\n`;
+
+  await fs.writeFile(targetPath, template, { flag: 'wx' });
+  return fileName;
+}

--- a/services/apps-service/src/startup.js
+++ b/services/apps-service/src/startup.js
@@ -4,6 +4,32 @@ import { logger } from './logger.js';
 import { runMongoMigrations, shouldRunMigrations } from './migrations.js';
 
 const SHUTDOWN_TIMEOUT_MS = 10_000;
+const MONGO_CONNECT_RETRIES = Number.parseInt(process.env.MONGO_CONNECT_RETRIES || '10', 10);
+const MONGO_CONNECT_RETRY_DELAY_MS = Number.parseInt(process.env.MONGO_CONNECT_RETRY_DELAY_MS || '1000', 10);
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function connectWithRetries(mongooseConnect, mongodbUri, appLogger, retries, retryDelayMs) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= retries; attempt += 1) {
+    try {
+      await mongooseConnect(mongodbUri);
+      return;
+    } catch (error) {
+      lastError = error;
+      const message = error?.message || String(error);
+      if (attempt < retries) {
+        appLogger.info({ attempt, retries, retryDelayMs, error: message }, 'mongo connection failed, retrying');
+        await wait(retryDelayMs);
+      }
+    }
+  }
+
+  throw lastError;
+}
 
 export function sanitizeConnectionString(connectionString) {
   if (typeof connectionString !== 'string') {
@@ -56,6 +82,8 @@ export async function startServer(
     setTimeoutFn = setTimeout,
     clearTimeoutFn = clearTimeout,
     shutdownTimeoutMs = SHUTDOWN_TIMEOUT_MS,
+    mongoConnectRetries = MONGO_CONNECT_RETRIES,
+    mongoConnectRetryDelayMs = MONGO_CONNECT_RETRY_DELAY_MS,
   } = {}
 ) {
   const app = appFactory({
@@ -73,7 +101,7 @@ export async function startServer(
       appLogger.info('mongodb migrations applied');
     }
 
-    await mongooseConnect(mongodbUri);
+    await connectWithRetries(mongooseConnect, mongodbUri, appLogger, mongoConnectRetries, mongoConnectRetryDelayMs);
     appLogger.info({ mongodbUri: sanitizeConnectionString(mongodbUri) }, 'connected to MongoDB');
 
     server = app.listen(port, () => {

--- a/services/apps-service/src/startup.js
+++ b/services/apps-service/src/startup.js
@@ -1,6 +1,7 @@
 import mongoose from 'mongoose';
 import { createApp } from './app.js';
 import { logger } from './logger.js';
+import { runMongoMigrations, shouldRunMigrations } from './migrations.js';
 
 const SHUTDOWN_TIMEOUT_MS = 10_000;
 
@@ -51,6 +52,7 @@ export async function startServer(
     appFactory = createApp,
     appLogger = logger,
     processRef = process,
+    runMigrations = runMongoMigrations,
     setTimeoutFn = setTimeout,
     clearTimeoutFn = clearTimeout,
     shutdownTimeoutMs = SHUTDOWN_TIMEOUT_MS,
@@ -66,6 +68,11 @@ export async function startServer(
   let server;
 
   try {
+    if (shouldRunMigrations(nodeEnv)) {
+      await runMigrations();
+      appLogger.info('mongodb migrations applied');
+    }
+
     await mongooseConnect(mongodbUri);
     appLogger.info({ mongodbUri: sanitizeConnectionString(mongodbUri) }, 'connected to MongoDB');
 

--- a/services/apps-service/tests/startup.test.js
+++ b/services/apps-service/tests/startup.test.js
@@ -41,6 +41,7 @@ describe('startup logging sanitization', () => {
         mongooseConnect: async () => {},
         appFactory: () => app,
         appLogger,
+        runMigrations: async () => {},
         processRef: { on: () => {}, exit: () => {} },
       }
     );
@@ -51,6 +52,39 @@ describe('startup logging sanitization', () => {
     assert.equal(connectionLog[0].mongodbUri, 'mongodb://***:***@localhost:27017/fullstack-pilot?authSource=admin');
     assert.equal(connectionLog[0].mongodbUri.includes('dbUser'), false);
     assert.equal(connectionLog[0].mongodbUri.includes('dbPassword'), false);
+  });
+
+
+  it('runs mongodb migrations before opening database connection in non-production', async () => {
+    const order = [];
+
+    await startServer(
+      {
+        port: 4000,
+        mongodbUri: 'mongodb://localhost:27017/fullstack-pilot',
+        serviceName: 'apps',
+        serviceBasePath: '/',
+        nodeEnv: 'development',
+      },
+      {
+        runMigrations: async () => {
+          order.push('migrations');
+        },
+        mongooseConnect: async () => {
+          order.push('connect');
+        },
+        appFactory: () => ({
+          listen: (_port, callback) => {
+            callback();
+            return { close: (cb) => cb() };
+          },
+        }),
+        appLogger: { info: () => {}, error: () => {} },
+        processRef: { on: () => {}, exit: () => {} },
+      }
+    );
+
+    assert.deepEqual(order, ['migrations', 'connect']);
   });
 
   it('gracefully shuts down HTTP server then MongoDB on SIGTERM', async () => {
@@ -93,6 +127,7 @@ describe('startup logging sanitization', () => {
         },
         appFactory: () => app,
         appLogger: { info: () => {}, error: () => {} },
+        runMigrations: async () => {},
         processRef,
         setTimeoutFn: () => 'timer-id',
         clearTimeoutFn: () => {},

--- a/services/apps-service/tests/startup.test.js
+++ b/services/apps-service/tests/startup.test.js
@@ -87,6 +87,41 @@ describe('startup logging sanitization', () => {
     assert.deepEqual(order, ['migrations', 'connect']);
   });
 
+
+  it('retries MongoDB connection before failing startup', async () => {
+    let attempts = 0;
+
+    await startServer(
+      {
+        port: 4000,
+        mongodbUri: 'mongodb://localhost:27017/fullstack-pilot',
+        serviceName: 'apps',
+        serviceBasePath: '/',
+      },
+      {
+        mongooseConnect: async () => {
+          attempts += 1;
+          if (attempts < 3) {
+            throw new Error('temporary connect failure');
+          }
+        },
+        appFactory: () => ({
+          listen: (_port, callback) => {
+            callback();
+            return { close: (cb) => cb() };
+          },
+        }),
+        appLogger: { info: () => {}, error: () => {} },
+        runMigrations: async () => {},
+        processRef: { on: () => {}, exit: () => {} },
+        mongoConnectRetries: 3,
+        mongoConnectRetryDelayMs: 0,
+      }
+    );
+
+    assert.equal(attempts, 3);
+  });
+
   it('gracefully shuts down HTTP server then MongoDB on SIGTERM', async () => {
     const events = [];
     const handlers = {};

--- a/services/dependencies-service/DependenciesService.csproj
+++ b/services/dependencies-service/DependenciesService.csproj
@@ -8,6 +8,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 </Project>

--- a/services/dependencies-service/Migrations/20260403000100_InitialCreate.cs
+++ b/services/dependencies-service/Migrations/20260403000100_InitialCreate.cs
@@ -1,0 +1,36 @@
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DependenciesService.Migrations
+{
+    [DbContext(typeof(DependenciesService.Data.DependenciesDbContext))]
+    [Migration("20260403000100_InitialCreate")]
+    public partial class InitialCreate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Dependencies",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(4000)", maxLength: 4000, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETUTCDATE()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Dependencies", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Dependencies");
+        }
+    }
+}

--- a/services/dependencies-service/Migrations/DependenciesDbContextModelSnapshot.cs
+++ b/services/dependencies-service/Migrations/DependenciesDbContextModelSnapshot.cs
@@ -1,0 +1,50 @@
+using System;
+using DependenciesService.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+#nullable disable
+
+namespace DependenciesService.Migrations
+{
+    [DbContext(typeof(DependenciesDbContext))]
+    partial class DependenciesDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+#pragma warning disable 612, 618
+            modelBuilder
+                .HasAnnotation("ProductVersion", "8.0.8")
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+
+            modelBuilder.Entity("DependenciesService.Models.Dependancy", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("datetime2")
+                        .HasDefaultValueSql("GETUTCDATE()");
+
+                    b.Property<string>("Description")
+                        .HasMaxLength(4000)
+                        .HasColumnType("nvarchar(4000)");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("nvarchar(200)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Dependencies");
+                });
+#pragma warning restore 612, 618
+        }
+    }
+}

--- a/services/dependencies-service/Program.cs
+++ b/services/dependencies-service/Program.cs
@@ -19,10 +19,17 @@ builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
 
+var migrateOnStartup = app.Environment.IsDevelopment() ||
+    builder.Configuration.GetValue("Database:MigrateOnStartup", true);
+
 using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<DependenciesDbContext>();
-    db.Database.EnsureCreated();
+
+    if (migrateOnStartup)
+    {
+        db.Database.Migrate();
+    }
 
     if (!db.Dependencies.Any())
     {

--- a/services/dependencies-service/README.md
+++ b/services/dependencies-service/README.md
@@ -67,3 +67,22 @@ Response format:
 ## Monitoring
 
 A simple middleware logs each HTTP request with the method, path, status code, and response time. When the service runs via `dotnet run` or Docker Compose, these events appear in the console logs to help track service health.
+
+## Database migrations (EF Core)
+Schema changes are versioned with EF Core migrations.
+The service uses `Database.Migrate()` during startup in `Development` (or when `Database:MigrateOnStartup=true`).
+Set `Database:MigrateOnStartup=false` only if migrations are executed explicitly by your deployment pipeline before service startup.
+
+Apply migrations manually:
+
+```bash
+cd services/dependencies-service
+dotnet ef database update
+```
+
+Create a new migration:
+
+```bash
+cd services/dependencies-service
+dotnet ef migrations add <MigrationName>
+```

--- a/services/dependencies-service/appsettings.json
+++ b/services/dependencies-service/appsettings.json
@@ -8,5 +8,8 @@
   "ConnectionStrings": {
     "DependenciesDb": "Server=localhost,1433;Database=DependenciesDb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=True;"
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Database": {
+    "MigrateOnStartup": true
+  }
 }

--- a/services/services-service/README.md
+++ b/services/services-service/README.md
@@ -66,3 +66,21 @@ Response format:
   "offset": 0
 }
 ```
+
+## Database migrations (Alembic)
+Schema changes are versioned with Alembic migrations and are no longer created/altered at runtime by the Flask app.
+
+Run migrations before starting the API:
+
+```bash
+cd services/services-service
+alembic -c alembic.ini upgrade head
+python app.py
+```
+
+Create a new migration:
+
+```bash
+cd services/services-service
+alembic -c alembic.ini revision -m "describe change"
+```

--- a/services/services-service/alembic.ini
+++ b/services/services-service/alembic.ini
@@ -1,0 +1,36 @@
+[alembic]
+script_location = alembic
+prepend_sys_path = .
+sqlalchemy.url = postgresql+psycopg://fullstack:fullstack@localhost:5432/fullstack-pilot
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/services/services-service/alembic/env.py
+++ b/services/services-service/alembic/env.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import os
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+config = context.config
+
+postgres_dsn = os.environ.get("POSTGRES_DSN")
+if postgres_dsn:
+    config.set_main_option("sqlalchemy.url", postgres_dsn.replace("postgresql://", "postgresql+psycopg://", 1))
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, literal_binds=True, dialect_opts={"paramstyle": "named"})
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/services/services-service/alembic/script.py.mako
+++ b/services/services-service/alembic/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/services/services-service/alembic/versions/20260403_01_initial_services_table.py
+++ b/services/services-service/alembic/versions/20260403_01_initial_services_table.py
@@ -1,0 +1,29 @@
+"""initial services table
+
+Revision ID: 20260403_01
+Revises:
+Create Date: 2026-04-03 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260403_01"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "services",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("app_id", sa.Text(), nullable=False, server_default=""),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("services")

--- a/services/services-service/requirements.txt
+++ b/services/services-service/requirements.txt
@@ -1,2 +1,4 @@
 Flask>=3.0,<4.0
 psycopg[binary,pool]>=3.1,<3.2
+SQLAlchemy>=2.0,<3.0
+alembic>=1.13,<2.0

--- a/services/services-service/service_api/db.py
+++ b/services/services-service/service_api/db.py
@@ -17,28 +17,6 @@ class ServicesRepository:
         conninfo = dsn or os.environ.get("POSTGRES_DSN") or DEFAULT_POSTGRES_DSN
         self.pool = ConnectionPool(conninfo=conninfo)
 
-    def init_schema(self) -> None:
-        """Ensure the backing table exists."""
-        with self.pool.connection() as connection:
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    """
-                    CREATE TABLE IF NOT EXISTS services (
-                        id SERIAL PRIMARY KEY,
-                        name TEXT NOT NULL,
-                        description TEXT NOT NULL DEFAULT '',
-                        app_id TEXT NOT NULL DEFAULT ''
-                    )
-                    """
-                )
-                cursor.execute(
-                    """
-                    ALTER TABLE services
-                    ADD COLUMN IF NOT EXISTS app_id TEXT NOT NULL DEFAULT ''
-                    """
-                )
-                connection.commit()
-
     def list_services(self, app_id: str, limit: int, offset: int) -> Dict[str, object]:
         with self.pool.connection() as connection:
             with connection.cursor(row_factory=dict_row) as cursor:

--- a/services/services-service/service_api/factory.py
+++ b/services/services-service/service_api/factory.py
@@ -20,8 +20,6 @@ def create_app() -> Flask:
     app.config["START_TIME"] = time.perf_counter()
     app.config["POSTGRES_DSN"] = os.environ.get("POSTGRES_DSN")
     repository = ServicesRepository(app.config["POSTGRES_DSN"])
-    repository.init_schema()
-
     app.config["REPOSITORY"] = repository
 
     @app.get("/healthz")

--- a/services/services-service/tests/test_factory_startup.py
+++ b/services/services-service/tests/test_factory_startup.py
@@ -1,0 +1,20 @@
+import unittest
+from unittest.mock import patch
+
+
+class FactoryStartupTest(unittest.TestCase):
+    @patch("service_api.factory.ServicesRepository")
+    def test_create_app_registers_repository_without_runtime_schema_init(self, repository_cls):
+        repository_instance = repository_cls.return_value
+
+        from service_api.factory import create_app
+
+        app = create_app()
+
+        self.assertIs(app.config["REPOSITORY"], repository_instance)
+        repository_cls.assert_called_once()
+        repository_instance.init_schema.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Ensure schema changes are versioned and applied via migrations instead of ad-hoc runtime schema edits. 
- Provide a consistent developer workflow for creating, running, and rolling back migrations across the polyglot datastores. 
- Run migrations in a controlled way at startup (or via explicit deployment step) and document the recommended practices.

### Description

- Added a top-level `docs/MIGRATIONS.md` and updated `README.md` and individual service READMEs with migration guidance for `apps-service` (Mongo), `services-service` (Postgres/Alembic), and `dependencies-service` (EF Core/SQL Server). 
- apps-service: implemented a migration runner (`src/migrationsRunner.js`), startup helpers (`src/migrations.js`), CLI script (`scripts/migrate.js`), package scripts in `package.json`, and an initial migration file under `migrations/20260403010000-initial-apps-collection.js`; integrated migration execution into `startup.js` when appropriate. 
- services-service: added Alembic scaffolding and an initial versioned migration under `alembic/versions/20260403_01_initial_services_table.py`, added `SQLAlchemy`/`alembic` requirements, and removed the previous runtime `init_schema()` call from the Flask app factory. 
- dependencies-service: added EF Core migration snapshot and initial migration files, updated `Program.cs` to use `Database.Migrate()` on startup controlled by `Database:MigrateOnStartup` configuration, and added `Microsoft.EntityFrameworkCore.Design` package metadata. 
- Tests: updated and added unit tests to assert startup behavior and migration ordering (`services/apps-service/tests/startup.test.js` and `services/services-service/tests/test_factory_startup.py`).

### Testing

- Ran `npm test` for `services/apps-service` (unit tests including `startup.test.js`) and the suite passed. 
- Ran Python unit tests for `services-service` via `python -m unittest` (includes `test_factory_startup.py`) and the tests passed. 
- Built the .NET project for `dependencies-service` (`dotnet build`) to validate the EF Core changes and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf267511548325b81dc3422e4ae6db)