### PR TITLE
Add autonomous AI-agent runner and supporting documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,17 @@
-# AGENT.md
+# AGENTS.md
 
 ## Mission
 - This repository hosts a full-stack system (React frontend + Node/Python/.NET backend services + Docker orchestration).
 - Optimize for minimal diffs, correctness, and consistency with existing architecture and patterns.
+
+## Repo structure overview
+- `client/`: React + Vite frontend.
+- `services/apps-service/`: Node + MongoDB API.
+- `services/services-service/`: Flask + PostgreSQL API.
+- `services/dependencies-service/`: .NET + SQL Server API.
+- `services/agent-service/`: internal AI-support service.
+- `docs/`: architecture, ADRs, and workflow docs.
+- `scripts/`: automation scripts.
 
 ## Scope Rules
 - Modify only files directly required by the task.
@@ -40,6 +49,12 @@
    - risks and tradeoffs,
    - remaining gaps or follow-ups.
 
+## Implementation Rules
+- Reuse existing patterns (routing, handlers, data access, config) before introducing alternatives.
+- Keep changes localized and minimal-diff first.
+- Prefer diff-based edits over broad rewrites.
+- Avoid speculative refactors or “while here” changes.
+
 ## Validation Policy
 - Frontend changes:
   - `npm --prefix client test -- --run`
@@ -57,20 +72,28 @@
 ## Architecture Constraints
 - Respect strict service boundaries between frontend, Node API, Python API, and .NET API.
 - Do not create tight coupling across services (shared internals, implicit cross-service dependencies).
-- Reuse existing patterns (routing, handlers, data access, config) before introducing alternatives.
 - Keep data flow and contracts consistent with current architecture/ADR decisions.
 
-## Quality Rules
-- Minimal diff first; avoid broad rewrites.
-- Eliminate duplication only within task scope.
-- No speculative refactors or “while here” changes.
-- Prioritize readability and maintainability over clever implementations.
+## Documentation Rules
 - Keep all documentation content in English (especially `README.md`).
+- Update only documentation impacted by implemented behavior.
+- `README.md` updates should be append-only unless explicitly requested.
 
 ## Failure Handling
 - If requirements are unclear, apply the simplest valid solution and state assumptions explicitly.
 - If context is missing, state what is missing and what decision was made with available information.
 - If validation cannot run, report exactly what was skipped and why.
+
+## PR Expectations
+- One focused branch and one focused commit per issue.
+- Include validation evidence and explicit assumptions in PR description.
+- Do not force push in automated flow.
+
+## DO NOT rules
+- Do not scan/load the full repository when targeted context is enough.
+- Do not introduce unrelated architecture or dependencies.
+- Do not commit changes that were not validated.
+- Do not include unrelated formatting-only edits.
 
 ## High-Signal Commands
 
@@ -123,3 +146,9 @@ Before starting any task that modifies code or infrastructure:
 No code change without a traceable issue. No exceptions.
 
 ---
+
+## Definition of Done
+- Requested behavior is implemented with minimal scope and localized diffs.
+- Validation checks pass (or skipped checks are explicitly justified).
+- Documentation is aligned with actual behavior.
+- Branch, single commit, and PR are created successfully.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This repo intentionally splits responsibilities across independent services so e
 
 ## AI-Native Development
 
-This repository is built and maintained using AI agents (OpenAI Codex).  
+This repository is built and maintained using AI agents.
 Agent behavior, scope rules, exploration strategy, and execution workflow are governed by [`AGENTS.md`](./AGENTS.md).
 
 ## Architecture decisions

--- a/README.md
+++ b/README.md
@@ -262,3 +262,35 @@ Additional local prerequisites for deterministic runs:
 - **Environment:** each service reads from a local `.env` file when present (e.g., `PORT`, `MONGODB_URI`, `POSTGRES_DSN`, `ASPNETCORE_URLS`, `ConnectionStrings__DependenciesDb`).
 - **Adding a service:** create `services/<new-service>`, include a runnable dev script (`npm run dev` or `start`), add a Dockerfile, expose a unique port, and wire it into `docker-compose.yml` (and `.devops` manifests if you want GitOps support).
 - **Scripts to know:** `npm run init` installs all service/client dependencies; `npm run start:services` starts every service that has a `dev`/`start` script; smoke tests live under `.devops/tests/smoke/`; `npm run test:all` runs the client plus all service test commands.
+
+## Autonomous Issue → PR runner
+A minimal deterministic runner is available at `scripts/ai-agent-run.js` for CI-oriented automation.
+
+### What it does
+- Calls three LLM roles in order: Planner → Implementer → Reviewer.
+- Enforces strict JSON contracts for each stage.
+- Applies code using unified diffs first (`git apply --check`), then `full_content` fallback when required.
+- Validates changes before commit (diff sanity, non-empty files, JS syntax check).
+- Creates `ai/issue-{id}` branch, performs a single commit, and pushes the branch.
+
+### Required environment
+- `OPENAI_BASE_URL` (OpenAI-compatible endpoint; defaults to `http://localhost:11434/v1`)
+- `OPENAI_API_KEY` (optional for local Ollama; default fallback is used)
+- `OPENAI_MODEL`
+
+### Usage
+```bash
+node scripts/ai-agent-run.js --issue-id=123 --issue="Implement X with Y constraints"
+# or
+node scripts/ai-agent-run.js --issue-id=123 --issue-file=.tmp/issue-123.md
+```
+
+### Local Llama/Qwen example (Ollama)
+```bash
+export OPENAI_BASE_URL=http://localhost:11434/v1
+export OPENAI_MODEL=qwen2.5-coder:14b
+# or: export OPENAI_MODEL=llama3.1:8b
+node scripts/ai-agent-run.js --issue-id=123 --issue-file=.tmp/issue-123.md
+```
+
+If any safety gate fails (invalid JSON, unsafe review, diff/apply failure, validation failure), the script aborts without committing.

--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -1,0 +1,80 @@
+# Agent Architecture: Issue → Code → PR
+
+## Roles
+
+### 1) Planner
+**Input:** raw issue text (+ optional metadata such as issue id/title/labels).  
+**Output contract:**
+
+```json
+{
+  "goal": "...",
+  "steps": [],
+  "impacted_files": [],
+  "assumptions": []
+}
+```
+
+**Responsibility**
+- Produce a deterministic, explicit plan.
+- Restrict scope to the smallest required file set.
+- State assumptions to make risk visible.
+
+### 2) Implementer
+**Input:** plan JSON + selected file context only.  
+**Output contract:**
+
+```json
+{
+  "changes": [
+    {
+      "file": "path/to/file",
+      "action": "create|modify|delete",
+      "diff": "UNIFIED DIFF ONLY",
+      "full_content": "REQUIRED only for create or if diff is ambiguous"
+    }
+  ],
+  "commit_message": "...",
+  "risk_level": "low|medium|high"
+}
+```
+
+**Responsibility**
+- Prefer valid unified diffs.
+- Keep edits minimal and localized.
+- Provide `full_content` fallback only when needed.
+
+### 3) Reviewer
+**Input:** implementer output (diff package).  
+**Output contract:**
+
+```json
+{
+  "status": "ok|needs_fix|unsafe",
+  "issues": [],
+  "suggestions": []
+}
+```
+
+**Responsibility**
+- Detect unsafe or unrelated edits.
+- Enforce contract and scope.
+- Gate commit on safety.
+
+## Boundaries
+- Planner cannot apply code.
+- Implementer cannot bypass reviewer gate.
+- Reviewer cannot edit code; it can only approve/reject with feedback.
+
+## Safety mechanisms
+- Strict JSON parsing at every role boundary (fail-fast).
+- Diff-first application (`git apply --check` before `git apply`).
+- Fallback to `full_content` only when diff cannot be safely applied.
+- Pre-commit validation: file existence, non-empty critical files, lightweight syntax sanity.
+- Abort states: invalid JSON, invalid diff, reviewer `unsafe`, validation failure.
+
+## Determinism controls
+- Fixed role order: Planner → Implementer → Reviewer.
+- Single retry only when reviewer returns `needs_fix`.
+- Single commit per run on branch `ai/issue-{id}`.
+- No force-push.

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1,0 +1,54 @@
+# Agent Workflow: Issue → Code → PR
+
+## Inputs
+- `issueId` (required): numeric or string issue identifier.
+- `issue` (required): issue text/body.
+- Environment for local OpenAI-compatible API:
+  - `OPENAI_BASE_URL`
+  - `OPENAI_MODEL`
+  - `OPENAI_API_KEY` (optional for local providers like Ollama; default fallback is used)
+
+## Pipeline (deterministic)
+1. **Read Issue**
+   - Validate required inputs.
+   - Abort if missing.
+2. **Planner call**
+   - Generate plan JSON.
+   - Abort if JSON invalid.
+3. **Context selection**
+   - Load only `README.md` + files listed in `impacted_files`.
+   - Never read full repository content.
+4. **Implementer call**
+   - Generate diff package JSON.
+   - Abort if JSON invalid.
+5. **Reviewer call**
+   - Return `ok | needs_fix | unsafe`.
+6. **Retry logic**
+   - If `needs_fix`: call implementer once with reviewer feedback, then re-review.
+   - If second review is not `ok`: abort.
+   - If `unsafe`: abort immediately.
+7. **Apply changes**
+   - Prefer `diff` via `git apply --check` then `git apply`.
+   - If diff fails and `full_content` exists: write content safely.
+   - If both fail: abort.
+8. **Validation before commit**
+   - Ensure target files exist per action.
+   - Ensure no empty critical files.
+   - Run `git diff --check` and lightweight syntax checks (for changed JS).
+   - On any failure: abort.
+9. **Git operations**
+   - Create/switch branch: `ai/issue-{id}`.
+   - Stage all intended changes.
+   - Single commit only.
+   - Push branch (no force push).
+10. **Open PR**
+   - Create PR from pushed branch with commit-aligned title/body.
+
+## Failure cases and safe abort conditions
+- Planner/Implementer/Reviewer emits invalid JSON.
+- Reviewer status `unsafe`.
+- Diff cannot be applied and no safe fallback available.
+- Validation fails.
+- Git branch/commit/push/PR step fails.
+
+In all failure modes: stop execution without partial commit state.

--- a/scripts/ai-agent-run.js
+++ b/scripts/ai-agent-run.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execSync } from 'node:child_process';
+
+const arg = (k) => process.argv.find((a) => a.startsWith(`--${k}=`))?.split('=').slice(1).join('=');
+const issueId = arg('issue-id');
+const issue = arg('issue') || (arg('issue-file') ? fs.readFileSync(arg('issue-file'), 'utf8') : '');
+if (!issueId || !issue) throw new Error('Usage: node scripts/ai-agent-run.js --issue-id=123 --issue="..."');
+
+const BASE = process.env.OPENAI_BASE_URL || 'http://localhost:11434/v1';
+const KEY = process.env.OPENAI_API_KEY || 'ollama';
+const MODEL = process.env.OPENAI_MODEL;
+if (!MODEL) throw new Error('Missing OPENAI_MODEL');
+
+const run = (c) => execSync(c, { stdio: 'pipe', encoding: 'utf8' }).trim();
+const parseJSON = (s) => { const m = s.match(/\{[\s\S]*\}$/); if (!m) throw new Error('Invalid JSON'); return JSON.parse(m[0]); };
+const chat = async (system, user) => {
+  const root = BASE.replace(/\/$/, '');
+  const endpoint = /\/v1$/.test(root) ? `${root}/chat/completions` : `${root}/v1/chat/completions`;
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${KEY}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model: MODEL, temperature: 0, response_format: { type: 'json_object' }, messages: [{ role: 'system', content: system }, { role: 'user', content: user }] })
+  });
+  if (!res.ok) throw new Error(`LLM error ${res.status}: ${await res.text()}`);
+  return parseJSON((await res.json()).choices?.[0]?.message?.content || '');
+};
+
+const readSafe = (f) => (fs.existsSync(f) ? fs.readFileSync(f, 'utf8') : '');
+const writeSafe = (f, content) => { fs.mkdirSync(path.dirname(f), { recursive: true }); fs.writeFileSync(f, content, 'utf8'); };
+const changedFiles = () => run('git diff --name-only').split('\n').filter(Boolean);
+
+const planner = async () => chat(
+  'You are Planner. Return only JSON: goal,steps,impacted_files,assumptions. Keep scope minimal.',
+  `Issue:\n${issue}`
+);
+
+const implementer = async (plan, feedback = '') => {
+  const files = (plan.impacted_files || []).slice(0, 30);
+  const context = ['README.md', ...files].filter((f, i, a) => a.indexOf(f) === i)
+    .map((f) => `### ${f}\n${readSafe(f).slice(0, 12000)}`).join('\n\n');
+  return chat(
+    'You are Implementer. Return only JSON contract with minimal changes. Use valid unified diffs. No unrelated edits.',
+    `Plan:\n${JSON.stringify(plan)}\n\nFeedback:${feedback || 'none'}\n\nContext:\n${context}`
+  );
+};
+
+const reviewer = async (changes) => chat(
+  'You are Reviewer. Return only JSON: status,issues,suggestions. Mark unsafe for risky/broad/unrelated edits.',
+  JSON.stringify(changes)
+);
+
+const applyDiff = (diff) => {
+  const p = path.join(os.tmpdir(), `ai-agent-${Date.now()}.patch`);
+  fs.writeFileSync(p, diff, 'utf8');
+  run(`git apply --check "${p}"`);
+  run(`git apply "${p}"`);
+};
+
+const applyChange = (c) => {
+  if (!c.file || !c.action) throw new Error('Invalid change entry');
+  if (c.diff) {
+    try { applyDiff(c.diff); return; } catch (_) { if (!c.full_content) throw new Error(`Diff failed: ${c.file}`); }
+  }
+  if (c.action === 'delete') { if (fs.existsSync(c.file)) fs.unlinkSync(c.file); return; }
+  if (typeof c.full_content !== 'string') throw new Error(`Missing full_content: ${c.file}`);
+  if (c.action === 'modify' && !fs.existsSync(c.file)) throw new Error(`Cannot modify missing file: ${c.file}`);
+  writeSafe(c.file, c.full_content);
+};
+
+const validate = () => {
+  run('git diff --check');
+  for (const f of changedFiles()) {
+    if (!fs.existsSync(f)) continue;
+    const txt = fs.readFileSync(f, 'utf8');
+    if (!txt.trim()) throw new Error(`Empty critical file: ${f}`);
+    if (f.endsWith('.js')) run(`node --check "${f}"`);
+  }
+  if (process.env.AGENT_VALIDATE_CMD) run(process.env.AGENT_VALIDATE_CMD);
+};
+
+const main = async () => {
+  const plan = await planner();
+  let ch = await implementer(plan);
+  let rv = await reviewer(ch);
+  if (rv.status === 'needs_fix') {
+    ch = await implementer(plan, JSON.stringify(rv));
+    rv = await reviewer(ch);
+  }
+  if (rv.status !== 'ok') throw new Error(`Reviewer blocked run: ${rv.status}`);
+
+  for (const c of (ch.changes || [])) applyChange(c);
+  validate();
+
+  const branch = `ai/issue-${issueId}`;
+  run(`git checkout -B ${branch}`);
+  run('git add -A');
+  run(`git commit -m ${JSON.stringify(ch.commit_message || `feat: resolve issue ${issueId}`)}`);
+  run(`git push -u origin ${branch}`);
+  run(`gh pr create --fill --head ${branch}`);
+  console.log(JSON.stringify({ status: 'ok', branch, commit_message: ch.commit_message, risk_level: ch.risk_level || 'unknown' }, null, 2));
+};
+
+main().catch((e) => { console.error(`ABORT: ${e.message}`); process.exit(1); });


### PR DESCRIPTION
### Motivation
- Provide a deterministic, minimal-scope automation for converting issues into PRs using a Planner→Implementer→Reviewer pipeline.
- Capture and enforce safety, validation, and repository conventions for AI-driven code changes. 
- Centralize operational details and usage for the runner so CI/local usage is reproducible and auditable.

### Description
- Add `scripts/ai-agent-run.js`, an executable Node script that implements the Planner→Implementer→Reviewer pipeline, diff-first application, validation, and PR creation flows. 
- Expand `AGENTS.md` with repo structure, execution and implementation rules, PR expectations, DO NOT rules, and a clear Definition of Done to guide automated and human contributors. 
- Update `README.md` to document the `scripts/ai-agent-run.js` runner, usage examples, required environment variables, and runtime behavior. 
- Add `docs/agent-architecture.md` and `docs/agent-workflow.md` to describe role contracts, safety mechanisms, deterministic pipeline steps, and failure/abort conditions.

### Testing
- Performed a lightweight syntax check with `node --check scripts/ai-agent-run.js`, which succeeded. 
- Verified that added documentation files are present and readable by opening `docs/agent-architecture.md` and `docs/agent-workflow.md` (manual file presence check). 
- No full service or integration test suite was executed as this change adds docs and a new runner without modifying service code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d322acd52883258bb5cc94497e6efa)