### PR TITLE
docs: add project cognitive ceiling assessment

### DIFF
--- a/docs/PROJECT_COGNITIVE_CEILING_ASSESSMENT.md
+++ b/docs/PROJECT_COGNITIVE_CEILING_ASSESSMENT.md
@@ -1,0 +1,47 @@
+# Project Cognitive Ceiling Assessment
+
+## Scope and method
+This assessment estimates two **separate IQ-correlated ceilings** from repository evidence:
+
+1. **Abstraction ceiling**: complexity and quality of architecture-level reasoning the project can sustain.
+2. **Implementation craft**: day-to-day engineering discipline and execution quality demonstrated in codebase organization and delivery workflow.
+
+These are not psychometric IQ tests. They are heuristic ranges mapped to IQ-like scales for comparative interpretation.
+
+## Evidence considered
+- Multi-service polyglot architecture (React + Node + Python + .NET + 3 datastores).
+- Explicit service boundaries and ownership model in architecture docs and ADRs.
+- GitOps workflow and CI/CD decomposition by workload.
+- Security hardening details (tokenized internal endpoints, rate limiting, fail-fast secret policy).
+- Operational readiness (health endpoints, structured logging, smoke tests, per-service testing commands).
+
+## Estimated ceilings
+
+### 1) Abstraction ceiling (architecture-level cognition)
+**Estimated IQ-correlated range: 132–142**  
+**Point estimate: 137**
+
+Rationale:
+- Strong boundary thinking (service/data ownership, anti-coupling posture).
+- Deliberate polyglot persistence with tradeoff awareness, not random technology sprawl.
+- ADR usage signals explicit long-horizon design memory.
+- GitOps + environment promotion indicates systems-level reasoning beyond single-service concerns.
+
+Primary limiter to pushing into a higher ceiling band:
+- Architecture is mature but still mostly "pragmatic product architecture" rather than deeply formalized distributed-systems rigor (e.g., explicit consistency models, SLO/SLA governance, failure-mode simulations as first-class artifacts).
+
+### 2) Implementation craft ceiling (execution-level cognition)
+**Estimated IQ-correlated range: 124–134**  
+**Point estimate: 129**
+
+Rationale:
+- Good operational hygiene (health checks, structured logs, smoke tests, guarded internal endpoints).
+- Reproducible local workflows and targeted per-service validation commands.
+- Clear conventions and maintainability orientation.
+
+Primary limiter:
+- Craft appears solid and professional, but not yet at the "elite reliability engineering" tier across all services (e.g., uniformly deep test depth, explicit reliability budgets, broad static analysis/mutation/security validation visible as mandatory gates).
+
+## Interpretation
+- The project demonstrates **higher architectural abstraction capacity than implementation-detail sophistication**, which is common in growing multi-service platforms.
+- In short: the system is designed with senior-level architectural judgment and good execution discipline, with most upside available in deeper reliability/testing rigor.


### PR DESCRIPTION
### Motivation
- Add a small, auditable assessment documenting heuristic estimates of two IQ-correlated ceilings ("Abstraction ceiling" and "Implementation craft") to capture architecture- and execution-level signals observed in the repository.

### Description
- Add `docs/PROJECT_COGNITIVE_CEILING_ASSESSMENT.md` which lists evidence considered, provides estimated IQ-correlated ranges and point estimates for both ceilings, explains rationale and primary limiters, and includes an interpretation of the gap between them.

### Testing
- Docs-only change; no runtime tests required, validated the new file and its contents with `rg`, `cat`, and `nl`, and committed the file successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4869f37d48325b9bbfd14fafc23ae)